### PR TITLE
fix: Move title and snippet columns above content_hash in documents . 

### DIFF
--- a/data/init.sql
+++ b/data/init.sql
@@ -8,6 +8,8 @@ CREATE TABLE IF NOT EXISTS documents (
     "offset" BIGINT, -- Byte offset in the file
     length BIGINT, -- Length of the compressed record
     doc_length INT DEFAULT 0, -- Number of words in the document
+    title TEXT, -- Page title extracted from HTML
+    snippet TEXT, -- Short text preview (first ~200 chars)
     content_hash VARCHAR(64) -- To detect duplicates
 );
 


### PR DESCRIPTION
closes : #21 Update the database schema to include title and snippet columns. This is a prerequisite for updating the Indexer to extract this information and the Ranker to serve it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced database schema to store document titles and snippet previews, enabling improved document presentation and browsing experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->